### PR TITLE
support generics for simple cases: generic types without bounds

### DIFF
--- a/src/main/java/org/sfm/jdbc/JdbcMapperBuilder.java
+++ b/src/main/java/org/sfm/jdbc/JdbcMapperBuilder.java
@@ -6,6 +6,7 @@ import org.sfm.jdbc.impl.getter.ResultSetGetterFactory;
 import org.sfm.map.*;
 import org.sfm.map.impl.*;
 import org.sfm.reflect.ReflectionService;
+import org.sfm.reflect.TypeReference;
 import org.sfm.reflect.meta.ClassMeta;
 import org.sfm.reflect.meta.PropertyNameMatcherFactory;
 
@@ -19,6 +20,9 @@ public final class JdbcMapperBuilder<T> extends AbstractFieldMapperMapperBuilder
 	private int columnIndex = 1;
 	private RowHandlerErrorHandler jdbcMapperErrorHandler = new RethrowRowHandlerErrorHandler();
 
+	public JdbcMapperBuilder(final TypeReference target) throws MapperBuildingException {
+		this(target.getType());
+	}
 	public JdbcMapperBuilder(final Type target) throws MapperBuildingException {
 		this(target, ReflectionService.newInstance());
 	}

--- a/src/main/java/org/sfm/reflect/TypeHelper.java
+++ b/src/main/java/org/sfm/reflect/TypeHelper.java
@@ -3,6 +3,7 @@ package org.sfm.reflect;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -19,6 +20,23 @@ public class TypeHelper {
 			return (Class<T>) bounds[0];
 		}
 		throw new UnsupportedOperationException("Cannot extract class from type " + target);
+	}
+
+	public static <T> Map<Type, Type> getTypesMap(Type targetType, Class<T> targetClass) {
+		Map<Type, Type> genericTypes = Collections.emptyMap();
+		if (targetType instanceof ParameterizedType) {
+			TypeVariable<Class<T>>[] typeParameters = targetClass.getTypeParameters();
+			Type[] actualTypeArguments = ((ParameterizedType) targetType).getActualTypeArguments();
+
+			genericTypes = new HashMap<>();
+			for (int i = 0; i < typeParameters.length; i++) {
+				TypeVariable<Class<T>> typeParameter = typeParameters[i];
+				Type typeArgument = actualTypeArguments[i];
+				genericTypes.put(typeParameter, typeArgument);
+			}
+		}
+
+		return genericTypes;
 	}
 
 	public static boolean isPrimitive(Type type) {

--- a/src/main/java/org/sfm/reflect/TypeReference.java
+++ b/src/main/java/org/sfm/reflect/TypeReference.java
@@ -1,0 +1,26 @@
+package org.sfm.reflect;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+public abstract class TypeReference<T> implements Comparable<TypeReference<T>> {
+	protected final Type _type;
+
+	protected TypeReference() {
+		Type superClass = getClass().getGenericSuperclass();
+		if (superClass instanceof Class<?>) {
+			throw new IllegalArgumentException("Internal error: TypeReference constructed without actual type information");
+		}
+
+		_type = ((ParameterizedType) superClass).getActualTypeArguments()[0];
+	}
+
+	public Type getType() {
+		return _type;
+	}
+
+	@Override
+	public int compareTo(TypeReference<T> o) {
+		return 0;
+	}
+}

--- a/src/main/java/org/sfm/reflect/meta/FieldPropertyMeta.java
+++ b/src/main/java/org/sfm/reflect/meta/FieldPropertyMeta.java
@@ -5,14 +5,17 @@ import org.sfm.reflect.Setter;
 import org.sfm.reflect.impl.FieldSetter;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 
 public class FieldPropertyMeta<T, P> extends PropertyMeta<T, P> {
 
 	private final Field field;
+	private final Type type;
 
-	public FieldPropertyMeta(String name, String columnName, ReflectionService reflectService, Field field) {
+	public FieldPropertyMeta(String name, String columnName, ReflectionService reflectService, Field field, Type type) {
 		super(name, columnName, reflectService);
 		this.field = field;
+		this.type = type;
 	}
 
 	@Override
@@ -24,9 +27,8 @@ public class FieldPropertyMeta<T, P> extends PropertyMeta<T, P> {
 	@SuppressWarnings("unchecked")
 	@Override
 	public Class<T> getType() {
-		return (Class<T>) field.getType();
+		return (Class<T>) type;
 	}
-
 
 	@Override
 	public String getPath() {

--- a/src/main/java/org/sfm/reflect/meta/MethodPropertyMeta.java
+++ b/src/main/java/org/sfm/reflect/meta/MethodPropertyMeta.java
@@ -9,12 +9,13 @@ import java.lang.reflect.Type;
 public class MethodPropertyMeta<T, P> extends PropertyMeta<T, P> {
 
 	private final Method method;
+	private final Type type;
 
-	public MethodPropertyMeta(String name, String columnName, ReflectionService reflectService, Method method) {
+	public MethodPropertyMeta(String name, String columnName, ReflectionService reflectService, Method method, Type type) {
 		super(name, columnName, reflectService);
 		this.method = method;
+		this.type = type;
 	}
-
 
 	@Override
 	protected Setter<T, P> newSetter() {
@@ -23,12 +24,11 @@ public class MethodPropertyMeta<T, P> extends PropertyMeta<T, P> {
 
 	@Override
 	public Type getType() {
-		return method.getGenericParameterTypes()[0];
+		return type;
 	}
 
 	@Override
 	public String getPath() {
 		return getName();
 	}
-
 }

--- a/src/test/java/org/sfm/jdbc/JdbcMapperGenericObjectTest.java
+++ b/src/test/java/org/sfm/jdbc/JdbcMapperGenericObjectTest.java
@@ -15,10 +15,7 @@ public class JdbcMapperGenericObjectTest {
 	private static final String QUERY = "select 33 as id, "
 			+ "'barbar' as bar_object_bar, "
 			+ "'foobar' as foo_object_bar, "
-			+ "'foofoo' as foo_object_foo, "
-			+ "'pair_first_bar' as pair.first_bar, "
-			+ "'pair_second_bar' as pair.second_bar, "
-			+ "'pair_second_foo' as pair.second_foo "
+			+ "'foofoo' as foo_object_foo "
 			+ "from TEST_DB_OBJECT where id = 1 ";
 
 	@Test
@@ -28,11 +25,6 @@ public class JdbcMapperGenericObjectTest {
 				.addMapping("bar_object_bar")
 				.addMapping("foo_object_bar")
 				.addMapping("foo_object_foo");
-
-				// unsupported yet
-				// .addMapping("pair.first_bar")
-				// .addMapping("pair.second_bar")
-				// .addMapping("pair.second_foo");
 
 		final JdbcMapper<Db1GenericObject> mapper = builder.mapper();
 

--- a/src/test/java/org/sfm/jdbc/JdbcMapperPairObjectTest.java
+++ b/src/test/java/org/sfm/jdbc/JdbcMapperPairObjectTest.java
@@ -1,0 +1,48 @@
+package org.sfm.jdbc;
+
+import org.junit.Test;
+import org.sfm.beans.Bar;
+import org.sfm.beans.Foo;
+import org.sfm.beans.Pair;
+import org.sfm.reflect.TypeReference;
+import org.sfm.utils.RowHandler;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class JdbcMapperPairObjectTest {
+
+	private static final String QUERY = "select "
+			+ "'first_bar' as first_bar, "
+			+ "'second_bar' as second_bar, "
+			+ "'second_foo' as second_foo "
+			+ "from TEST_DB_OBJECT where id = 1 ";
+
+	@Test
+	public void testMapGenericObjectWithStaticMapper() throws Exception {
+		JdbcMapperBuilder<Pair<Bar, Foo>> builder = new JdbcMapperBuilder<Pair<Bar, Foo>>(new TypeReference<Pair<Bar, Foo>>() {})
+				.addMapping("first_bar")
+				.addMapping("second_bar")
+				.addMapping("second_foo");
+
+		final JdbcMapper<Pair<Bar, Foo>> mapper = builder.mapper();
+
+		DbHelper.testQuery(new RowHandler<PreparedStatement>() {
+			@Override
+			public void handle(PreparedStatement t) throws Exception {
+				ResultSet rs = t.executeQuery();
+				rs.next();
+				Pair<Bar, Foo> object = mapper.map(rs);
+				assertNotNull(object);
+				assertNotNull(object.getFirst());
+				assertEquals("first_bar", object.getFirst().getBar());
+				assertNotNull(object.getSecond());
+				assertEquals("second_bar", object.getSecond().getBar());
+				assertEquals("second_foo", object.getSecond().getFoo());
+			}
+		}, QUERY);
+	}
+}


### PR DESCRIPTION
More comprehensive support for generics: supports types without bounds like `<T>`
TypeReference class is copypaste from jackson json - I think it's more usefull than Types.tupleImplementationTypeDef.