### PR TITLE
Avoid an IllegalArgumentException

### DIFF
--- a/sfm-jooq/src/main/java/org/sfm/jooq/getter/EnumRecordNamedGetter.java
+++ b/sfm-jooq/src/main/java/org/sfm/jooq/getter/EnumRecordNamedGetter.java
@@ -8,7 +8,7 @@ public final class EnumRecordNamedGetter<R extends Record, E extends Enum<E>> im
 
 	private final int index;
 	private final Class<E> enumType;
-	
+
 	public EnumRecordNamedGetter(final JooqFieldKey key, Class<E> enumType) {
 		this.index = key.getIndex();
 		this.enumType = enumType;
@@ -17,6 +17,9 @@ public final class EnumRecordNamedGetter<R extends Record, E extends Enum<E>> im
 	@Override
 	public E get(final R target) throws Exception {
 		final Object o = target.getValue(index);
+		if (o == null) {
+			return null;
+		}
 		return (E) Enum.valueOf(enumType, String.valueOf(o));
 	}
 }

--- a/sfm-jooq/src/main/java/org/sfm/jooq/getter/EnumRecordOrdinalGetter.java
+++ b/sfm-jooq/src/main/java/org/sfm/jooq/getter/EnumRecordOrdinalGetter.java
@@ -5,11 +5,11 @@ import org.sfm.jooq.JooqFieldKey;
 import org.sfm.reflect.EnumHelper;
 import org.sfm.reflect.Getter;
 
-public final class EnumRecordOrdinalGetter<R extends Record, E extends Enum<E>> implements  Getter<R, E> {
+public final class EnumRecordOrdinalGetter<R extends Record, E extends Enum<E>> implements Getter<R, E> {
 
 	private final int index;
 	private final E[] values;
-	
+
 
 	public EnumRecordOrdinalGetter(JooqFieldKey key, final Class<E> enumType) {
 		this.index = key.getIndex();
@@ -18,6 +18,10 @@ public final class EnumRecordOrdinalGetter<R extends Record, E extends Enum<E>> 
 
 	@Override
 	public E get(final R target) throws Exception {
-		return values[((Number)target.getValue(index)).intValue()];
+		Object value = target.getValue(index);
+		if (value == null) {
+			return null;
+		}
+		return values[((Number) value).intValue()];
 	}
 }

--- a/sfm-jooq/src/test/java/org/sfm/jooq/JooqMapperTest.java
+++ b/sfm-jooq/src/test/java/org/sfm/jooq/JooqMapperTest.java
@@ -48,7 +48,7 @@ public class JooqMapperTest {
 		List<DbObject> list = dsl.select()
 				.from("TEST_DB_OBJECT").fetchInto(DbObject.class);
 		
-		assertEquals(1, list.size());
+		assertEquals(2, list.size());
 
 		assertEquals(0, list.get(0).getId());
 		list.get(0).setId(1);
@@ -67,7 +67,7 @@ public class JooqMapperTest {
 		List<DbObject> list = dsl.select()
 				.from("TEST_DB_OBJECT").fetchInto(DbObject.class);
 
-		assertEquals(1, list.size());
+		assertEquals(2, list.size());
 		DbHelper.assertDbObjectMapping(list.get(0));
 	}
 	

--- a/sfm-test/src/main/java/org/sfm/test/jdbc/DbHelper.java
+++ b/sfm-test/src/main/java/org/sfm/test/jdbc/DbHelper.java
@@ -47,7 +47,8 @@ public class DbHelper {
 				createDbObject(st);
 
 				st.execute("insert into TEST_DB_OBJECT values(1, 'name 1', 'name1@mail.com', TIMESTAMP'2014-03-04 11:10:03', 2, 'type4')");
-				
+				st.execute("insert into TEST_DB_OBJECT values(2, null, null, null, null, null)");
+
 				
 				st.execute("create table db_extended_type("
 						+ " bytes varbinary(10),"


### PR DESCRIPTION
where String.valueOf(null) returns…"null" and you can't have an enum value named "null".