### PR TITLE
Allow partial match like column: abc_def_ghi -> prop: abcGhi.defGhi

### DIFF
--- a/sfm-reflect/src/main/java/org/simpleflatmapper/reflect/meta/DefaultPropertyNameMatcher.java
+++ b/sfm-reflect/src/main/java/org/simpleflatmapper/reflect/meta/DefaultPropertyNameMatcher.java
@@ -89,6 +89,7 @@ public final class DefaultPropertyNameMatcher implements PropertyNameMatcher {
 		int indexColumn = from;
 		int indexProperty = 0;
 		boolean nextToUpperCase = false;
+		boolean prevSeparator = false;
 		do {
 			if (indexProperty < property.length()) {
 				char charProperty = property.charAt(indexProperty);
@@ -102,6 +103,7 @@ public final class DefaultPropertyNameMatcher implements PropertyNameMatcher {
 					indexColumn ++;
 					
 					if (ignoreCharacter(charColumn)) {
+						prevSeparator = true;
 						if (ignoreCharacter(charProperty)) {
 							indexProperty++;
 						}
@@ -109,9 +111,15 @@ public final class DefaultPropertyNameMatcher implements PropertyNameMatcher {
 							nextToUpperCase = true;
 						}
 					} else if (areDifferentCharacters(charProperty, charColumn)) {
-						return -1;
+						if (prevSeparator) {
+							int index = indexColumn - 2; // Capture: [abc]_def
+							return index > 0 ? index : -1;
+						} else {
+							return -1;
+						}
 					} else {
 						indexProperty++;
+						prevSeparator = false;
 					}
 				} else {
 					return -1;


### PR DESCRIPTION
The partial matcher has allowed the matching:
- abc_def_ghi -> abc.defGhi

This change is going to allow the matching too:
- abc_def_ghi -> prop: abcGhi.defGhi

Since I want to map the case below without defining specific mapping:
Columns on the table:
```
scheduled_start_date
scheduled_end_date
```
Entity
```
class Entity {
  DateRange scheduledDate;
}
class DateRange {
  Date startDate;
  Date endDate;
}
```

Please consider to merge it. Thanks!



