### PR TITLE
add DSLContextProvider to decouple Jooq configuration

### DIFF
--- a/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/DSLContextProvider.java
+++ b/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/DSLContextProvider.java
@@ -1,0 +1,9 @@
+package org.simpleflatmapper.jooq;
+
+import org.jooq.DSLContext;
+
+public interface DSLContextProvider {
+
+    DSLContext provide();
+
+}

--- a/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/JooqMapperFactory.java
+++ b/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/JooqMapperFactory.java
@@ -1,6 +1,5 @@
 package org.simpleflatmapper.jooq;
 
-import org.jooq.Configuration;
 import org.jooq.Record;
 import org.simpleflatmapper.map.MapperConfig;
 import org.simpleflatmapper.map.getter.ContextualGetterFactoryAdapter;
@@ -49,13 +48,13 @@ public class JooqMapperFactory
     }
 
     //IFJAVA8_START
-    public SfmRecordUnmapperProvider newRecordUnmapperProvider(Configuration configuration) {
+    public SfmRecordUnmapperProvider newRecordUnmapperProvider(DSLContextProvider dslContextProvider) {
         return new SfmRecordUnmapperProvider(new Function<Type, MapperConfig<JooqFieldKey, Record>>() {
             @Override
             public MapperConfig<JooqFieldKey, Record> apply(Type type) {
                 return mapperConfig(type);
             }
-        }, getReflectionService(), configuration);
+        }, getReflectionService(), dslContextProvider);
     }
     //IFJAVA8_END
 

--- a/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/RecordUnmapperBuilder.java
+++ b/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/RecordUnmapperBuilder.java
@@ -52,24 +52,24 @@ public class RecordUnmapperBuilder<E> extends AbstractConstantTargetMapperBuilde
     };
 
     private Field[] fields;
-    private final Configuration configuration;
+    private final DSLContextProvider dslContextProvider;
 
     public RecordUnmapperBuilder(
             ClassMeta<E> classMeta,
             MapperConfig<JooqFieldKey, ?> mapperConfig,
-            Configuration configuration) {
+            DSLContextProvider dslContextProvider) {
         super(classMeta, Record.class, mapperConfig, ConstantTargetFieldMapperFactoryImpl.newInstance(SETTER_FACTORY, Record.class));
-        this.configuration = configuration;
+        this.dslContextProvider = dslContextProvider;
     }
 
     @Override
     protected BiInstantiator<E, MappingContext<? super E>, Record> getInstantiator() {
         final Field[] fields = this.fields;
-        final Configuration conf = this.configuration;
+        final DSLContextProvider dslContextProvider = this.dslContextProvider;
         return new BiInstantiator<E, MappingContext<? super E>, Record>() {
             @Override
             public Record newInstance(E e, MappingContext<? super E> mappingContext) {
-                return DSL.using(conf).newRecord(fields);
+                return dslContextProvider.provide().newRecord(fields);
             }
         };
     }

--- a/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/SfmRecordUnmapperProvider.java
+++ b/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/SfmRecordUnmapperProvider.java
@@ -20,17 +20,17 @@ public class SfmRecordUnmapperProvider implements RecordUnmapperProvider {
 	private final ConcurrentMap<TargetColumnsMapperKey, ContextualSourceMapper> mapperCache = new ConcurrentHashMap<TargetColumnsMapperKey, ContextualSourceMapper>();
 	private final Function<Type, MapperConfig<JooqFieldKey, Record>> mapperConfigFactory;
 	private final ReflectionService reflectionService;
-	private final Configuration configuration;
+	private final DSLContextProvider dslContextProvider;
 
 	@Deprecated
 	/**
 	 * please use SfmRecorMapperProviderFactory.
 	 */
 	public SfmRecordUnmapperProvider(
-			Function<Type, MapperConfig<JooqFieldKey, Record>> mapperConfigFactory, ReflectionService reflectionService, Configuration configuration) {
+			Function<Type, MapperConfig<JooqFieldKey, Record>> mapperConfigFactory, ReflectionService reflectionService, DSLContextProvider dslContextProvider) {
 		this.mapperConfigFactory = mapperConfigFactory;
 		this.reflectionService = reflectionService;
-		this.configuration = configuration;
+		this.dslContextProvider = dslContextProvider;
 	}
 
 	@Override
@@ -46,7 +46,7 @@ public class SfmRecordUnmapperProvider implements RecordUnmapperProvider {
 			RecordUnmapperBuilder<E> mapperBuilder =
 					new RecordUnmapperBuilder<E>(
 							reflectionService.<E>getClassMeta(type),
-							mapperConfig, configuration);
+							mapperConfig, dslContextProvider);
 
 			mapperBuilder.setFields(recordType.fields());
 

--- a/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/JooqUnmapperTest.java
+++ b/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/JooqUnmapperTest.java
@@ -4,7 +4,10 @@ import org.jooq.*;
 import org.jooq.impl.DSL;
 import org.jooq.impl.DefaultConfiguration;
 import org.junit.Test;
-import org.simpleflatmapper.jooq.*;
+import org.simpleflatmapper.jooq.DSLContextProvider;
+import org.simpleflatmapper.jooq.JooqMapperFactory;
+import org.simpleflatmapper.jooq.JooqRecordUnmapperWrapper;
+import org.simpleflatmapper.jooq.SfmRecordUnmapperProvider;
 import org.simpleflatmapper.jooq.test.books.Label;
 import org.simpleflatmapper.jooq.test.books.Labels;
 import org.simpleflatmapper.jooq.test.books.LabelsRecord;
@@ -14,10 +17,8 @@ import org.simpleflatmapper.test.jdbc.DbHelper;
 import java.sql.Connection;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class JooqUnmapperTest {
 
@@ -26,7 +27,8 @@ public class JooqUnmapperTest {
 	@SuppressWarnings("unchecked")
 	public void testCacheMapper() {
 
-		SfmRecordUnmapperProvider recordMapperProvider = JooqMapperFactory.newInstance().newRecordUnmapperProvider(null);
+		SfmRecordUnmapperProvider recordMapperProvider = JooqMapperFactory.newInstance()
+				.newRecordUnmapperProvider(null);
 		RecordType rt = mock(RecordType.class);
 		Field field1 = mock(Field.class);
 		when(field1.getName()).thenReturn("id");
@@ -49,7 +51,12 @@ public class JooqUnmapperTest {
 				.set(conn)
 				.set(SQLDialect.HSQLDB);
 
-		cfg.set(JooqMapperFactory.newInstance().newRecordUnmapperProvider(cfg));
+		cfg.set(JooqMapperFactory.newInstance().newRecordUnmapperProvider(new DSLContextProvider() {
+			@Override
+			public DSLContext provide() {
+				return DSL.using(cfg);
+			}
+		}));
 
 		DSLContext dsl = DSL.using(cfg);
 


### PR DESCRIPTION
`JooqMapperFactory.newRecordUnmapperProvider()` requires a `org.jooq.Configuration`, in the meantime `RecordUnmapperProvider` is also a setting for `org.jooq.Configuration`. This will cause cycle dependencies when creating `org.jooq.Configuration` instance. This `DSLContextProvider` could be introduced to decouple both.