### PR TITLE
Add JooqBiConverter to help JooqRecord <-> Java Object custom conversion

### DIFF
--- a/sfm-converter/pom.xml
+++ b/sfm-converter/pom.xml
@@ -69,7 +69,13 @@
 					</execution>
 				</executions>
 			</plugin>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<trimStackTrace>false</trimStackTrace>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<profiles>

--- a/sfm-converter/pom.xml
+++ b/sfm-converter/pom.xml
@@ -69,13 +69,6 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<trimStackTrace>false</trimStackTrace>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 	<profiles>

--- a/sfm-converter/src/test/java/org/simpleflatmapper/converter/test/ConverterServiceTest.java
+++ b/sfm-converter/src/test/java/org/simpleflatmapper/converter/test/ConverterServiceTest.java
@@ -1,28 +1,19 @@
 package org.simpleflatmapper.converter.test;
 
 import org.junit.Test;
-import org.simpleflatmapper.converter.ComposedContextualConverter;
-import org.simpleflatmapper.converter.ConversionException;
-import org.simpleflatmapper.converter.ContextualConverter;
-import org.simpleflatmapper.converter.Converter;
-import org.simpleflatmapper.converter.ConverterFactoryProducer;
-import org.simpleflatmapper.converter.ConverterService;
-import org.simpleflatmapper.converter.EmptyContextFactoryBuilder;
-import org.simpleflatmapper.converter.ToStringConverter;
+import org.simpleflatmapper.converter.*;
 import org.simpleflatmapper.converter.impl.CharSequenceIntegerConverter;
 import org.simpleflatmapper.util.date.DateFormatSupplier;
 
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.net.MalformedURLException;
 import java.net.URL;
-
 import java.net.URLClassLoader;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
@@ -205,6 +196,21 @@ public class ConverterServiceTest {
         });
         
         assertEquals(new SimpleDateFormat("yyyyMMdd").parse("20180927"), dateConv.convert("20180927"));
+    }
 
+    @Test
+    public void testListToArrayConverter() throws Exception {
+        ConverterService converterService = ConverterService.getInstance();
+        Converter<? super List, ? extends String[]> converter = converterService.findConverter(List.class, String[].class);
+        assertNotNull(converter);
+
+        List<String> strList = new ArrayList<>();
+        strList.add("a");
+        strList.add("b");
+        strList.add("c");
+        String[] strArr = converter.convert(strList);
+        assertEquals(strList.get(0), strArr[0]);
+        assertEquals(strList.get(1), strArr[1]);
+        assertEquals(strList.get(2), strArr[2]);
     }
 }

--- a/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/JooqBiConverter.java
+++ b/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/JooqBiConverter.java
@@ -1,0 +1,66 @@
+package org.simpleflatmapper.jooq;
+
+import org.jooq.Record;
+import org.simpleflatmapper.converter.*;
+import org.simpleflatmapper.map.FieldKey;
+import org.simpleflatmapper.map.context.MappingContextFactoryBuilder;
+import org.simpleflatmapper.map.getter.ContextualGetter;
+import org.simpleflatmapper.map.getter.ContextualGetterFactory;
+import org.simpleflatmapper.map.property.ContextualConverterFactoryProperty;
+import org.simpleflatmapper.map.property.GetterFactoryProperty;
+import org.simpleflatmapper.util.TypeHelper;
+
+import java.lang.reflect.Type;
+import java.util.Collection;
+
+public abstract class JooqBiConverter<F, M> implements ContextualGetter<F, M>, ContextualConverter<M, F> {
+
+    public abstract boolean match(Type modelType);
+
+    protected Type getRecordFieldType() {
+        Type[] types = TypeHelper.getGenericParameterForClass(this.getClass(), ContextualGetter.class);
+        return types != null ? types[0] : null;
+    }
+
+    protected Type getObjectType() {
+        Type[] types = TypeHelper.getGenericParameterForClass(this.getClass(), ContextualGetter.class);
+        return types != null ? types[1] : null;
+    }
+
+    public <R extends Record> GetterFactoryProperty buildGetterProperty() {
+        ContextualGetterFactory<R, JooqFieldKey> getterFactory = new ContextualGetterFactory<R, JooqFieldKey>() {
+            @Override
+            public <P> ContextualGetter<R, P> newGetter(Type target, JooqFieldKey key,
+                                                        MappingContextFactoryBuilder<?, ? extends FieldKey<?>> mappingContextFactoryBuilder,
+                                                        Object... properties) {
+                if (!JooqBiConverter.this.match(target)) return null;
+                final int index = key.getIndex();
+                return new ContextualGetter<R, P>() {
+                    @Override
+                    public P get(R record, Context context) throws Exception {
+                        return (P) JooqBiConverter.this.get((F) record.get(index), context);
+                    }
+                };
+            }
+        };
+
+        return new GetterFactoryProperty(getterFactory);
+    }
+
+    public static ContextualConverterFactoryProperty buildConverterProperty(final Collection<JooqBiConverter> converters) {
+        ContextualConverterFactory<?, ?> converterFactory =
+                new AbstractContextualConverterFactory<Object, Object>(Object.class, Object.class) {
+            @Override
+            public ContextualConverter<Object, Object> newConverter(ConvertingTypes targetedTypes,
+                                                                    ContextFactoryBuilder contextFactoryBuilder,
+                                                                    Object... params) {
+                for (JooqBiConverter converter : converters) {
+                    if (!converter.match(targetedTypes.getFrom())) continue;
+                    return converter;
+                }
+                return null;
+            }
+        };
+        return ContextualConverterFactoryProperty.of(converterFactory);
+    }
+}

--- a/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/JooqMapperFactory.java
+++ b/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/JooqMapperFactory.java
@@ -8,9 +8,11 @@ import org.simpleflatmapper.map.mapper.AbstractColumnNameDiscriminatorMapperFact
 import org.simpleflatmapper.map.mapper.AbstractMapperFactory;
 import org.simpleflatmapper.map.mapper.FieldMapperColumnDefinitionProviderImpl;
 import org.simpleflatmapper.map.property.FieldMapperColumnDefinition;
+import org.simpleflatmapper.util.ConstantPredicate;
 import org.simpleflatmapper.util.Function;
 
 import java.lang.reflect.Type;
+import java.util.List;
 
 public class JooqMapperFactory
         extends AbstractColumnNameDiscriminatorMapperFactory<JooqFieldKey, JooqMapperFactory, Record> {
@@ -24,7 +26,6 @@ public class JooqMapperFactory
         return new JooqMapperFactory(config);
     }
 
-
     private JooqMapperFactory() {
         super(new FieldMapperColumnDefinitionProviderImpl<JooqFieldKey>(), FieldMapperColumnDefinition.<JooqFieldKey>identity(), new ContextualGetterFactoryAdapter<Record, JooqFieldKey>(new RecordGetterFactory()));
     }
@@ -37,6 +38,14 @@ public class JooqMapperFactory
         super(columnDefinitions, identity, new ContextualGetterFactoryAdapter<Record, JooqFieldKey>(new RecordGetterFactory()));
     }
 
+    public JooqMapperFactory addBiConverters(List<JooqBiConverter> converters) {
+        for (JooqBiConverter converter : converters) {
+            addColumnProperty(ConstantPredicate.truePredicate(), converter.buildGetterProperty());
+        }
+        addColumnProperty(ConstantPredicate.truePredicate(),
+                JooqBiConverter.buildConverterProperty(converters));
+        return this;
+    }
 
     public SfmRecordMapperProvider newRecordMapperProvider() {
         return new SfmRecordMapperProvider(new Function<Type, MapperConfig<JooqFieldKey, Record>>() {

--- a/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/RecordUnmapperBuilder.java
+++ b/sfm-jooq/src/main/java/org/simpleflatmapper/jooq/RecordUnmapperBuilder.java
@@ -1,21 +1,20 @@
 package org.simpleflatmapper.jooq;
 
 
-import org.jooq.Configuration;
 import org.jooq.Field;
 import org.jooq.Record;
-import org.jooq.impl.DSL;
 import org.simpleflatmapper.converter.*;
-import org.simpleflatmapper.map.*;
+import org.simpleflatmapper.map.MapperConfig;
+import org.simpleflatmapper.map.MappingContext;
 import org.simpleflatmapper.map.mapper.AbstractConstantTargetMapperBuilder;
 import org.simpleflatmapper.map.mapper.ConstantTargetFieldMapperFactoryImpl;
 import org.simpleflatmapper.map.mapper.PropertyMapping;
-import org.simpleflatmapper.map.property.ConverterProperty;
+import org.simpleflatmapper.map.property.ContextualConverterFactoryProperty;
 import org.simpleflatmapper.map.property.FieldMapperColumnDefinition;
 import org.simpleflatmapper.map.setter.ContextualSetter;
 import org.simpleflatmapper.map.setter.ContextualSetterFactory;
-import org.simpleflatmapper.reflect.*;
-import org.simpleflatmapper.reflect.meta.*;
+import org.simpleflatmapper.reflect.BiInstantiator;
+import org.simpleflatmapper.reflect.meta.ClassMeta;
 import org.simpleflatmapper.util.TypeHelper;
 
 import java.lang.reflect.Type;
@@ -34,11 +33,14 @@ public class RecordUnmapperBuilder<E> extends AbstractConstantTargetMapperBuilde
             if (TypeHelper.isAssignable(fieldType, propertyType)) {
                 return new RecordContextualSetter<P>((Field<? super P>) field);
             } else {
-                ContextualConverter converter;
-                if (pm.getColumnDefinition().has(ConverterProperty.class)) {
-                    ConverterProperty converterProperty = pm.getColumnDefinition().lookFor(ConverterProperty.class);
-                    converter = converterProperty.function;
-                } else {
+                ContextualConverter converter = null;
+                if (pm.getColumnDefinition().has(ContextualConverterFactoryProperty.class)) {
+                    ContextualConverterFactoryProperty contextualConverterFactoryProperty = pm.getColumnDefinition().lookFor(ContextualConverterFactoryProperty.class);
+                    converter = contextualConverterFactoryProperty.factory.newConverter(
+                            new ConvertingTypes(propertyType, fieldType), contextFactoryBuilder);
+                }
+
+                if (converter == null) {
                     converter = ConverterService.getInstance().findConverter(propertyType, fieldType, contextFactoryBuilder, pm.getColumnDefinition().properties());
                 }
 

--- a/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/JooqBiConverterTest.java
+++ b/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/JooqBiConverterTest.java
@@ -1,0 +1,93 @@
+package org.simpleflatmapper.jooq.test;
+
+import org.jooq.Configuration;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.jooq.impl.DefaultConfiguration;
+import org.junit.Test;
+import org.simpleflatmapper.converter.Context;
+import org.simpleflatmapper.jooq.DSLContextProvider;
+import org.simpleflatmapper.jooq.JooqBiConverter;
+import org.simpleflatmapper.jooq.JooqMapperFactory;
+import org.simpleflatmapper.jooq.test.books.Label;
+import org.simpleflatmapper.jooq.test.books.Labels;
+import org.simpleflatmapper.jooq.test.books.LabelsRecord;
+import org.simpleflatmapper.test.jdbc.DbHelper;
+import org.simpleflatmapper.util.TypeHelper;
+
+import java.lang.reflect.Type;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+public class JooqBiConverterTest {
+
+	//IFJAVA8_START
+	@Test
+	public void testUnmapping() throws Exception {
+		Connection conn = DbHelper.objectDb();
+
+		Configuration cfg = new DefaultConfiguration()
+				.set(conn)
+				.set(SQLDialect.HSQLDB);
+
+		List<JooqBiConverter> converters = new ArrayList<>();
+		converters.add(new JooqBiConverter<String, JSONObjectTest494.File>() {
+			@Override
+			public boolean match(Type modelType) {
+				return TypeHelper.areEquals(modelType, JSONObjectTest494.File.class);
+			}
+			@Override
+			public JSONObjectTest494.File get(String name, Context context) throws Exception {
+				return new JSONObjectTest494.File(0L, name, null);
+			}
+			@Override
+			public String convert(JSONObjectTest494.File file, Context context) throws Exception {
+				return file.name;
+			}
+		});
+
+		DSLContextProvider contextProvider = new DSLContextProvider() {
+			@Override
+			public DSLContext provide() {
+				return DSL.using(cfg);
+			}
+		};
+		JooqMapperFactory mapperFactory = JooqMapperFactory.newInstance()
+				.addBiConverters(converters);
+
+		cfg.set(mapperFactory.newRecordMapperProvider())
+		   .set(mapperFactory.newRecordUnmapperProvider(contextProvider));
+
+		DSLContext dsl = DSL.using(cfg);
+
+		LabelsRecord labelsRecord = dsl.newRecord(Labels.LABELS);
+		labelsRecord.setId(1);
+		labelsRecord.setUuid(UUID.randomUUID());
+		labelsRecord.setName("label");
+		labelsRecord.setObsolete(false);
+		labelsRecord.setFile("testFile");
+
+		// test from Record -> Object
+		Label label = labelsRecord.into(Label.class);
+		assertEquals(labelsRecord.getId(), label.getId());
+		assertEquals(labelsRecord.getName(), label.getName());
+		assertEquals(labelsRecord.getUuid(), label.getUuid());
+		assertEquals(labelsRecord.getObsolete(), label.getObsolete());
+		assertEquals(labelsRecord.getFile(), label.getFile().name);
+
+		// test from Object -> Record
+		labelsRecord = dsl.newRecord(Labels.LABELS, label);
+		assertEquals(label.getId(), labelsRecord.getId());
+		assertEquals(label.getName(), labelsRecord.getName());
+		assertEquals(label.getUuid(), labelsRecord.getUuid());
+		assertEquals(label.getObsolete(), labelsRecord.getObsolete());
+		assertEquals(label.getFile().name, labelsRecord.getFile());
+	}
+	//IFJAVA8_END
+
+}

--- a/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/JooqUnmapperTest.java
+++ b/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/JooqUnmapperTest.java
@@ -60,7 +60,7 @@ public class JooqUnmapperTest {
 
 		DSLContext dsl = DSL.using(cfg);
 
-		Label label = new Label(1, UUID.randomUUID(), "label", false);
+		Label label = new Label(1, UUID.randomUUID(), "label", false, null);
 
 		LabelsRecord labelsRecord = dsl.newRecord(Labels.LABELS, label);
 

--- a/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/books/Label.java
+++ b/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/books/Label.java
@@ -1,5 +1,7 @@
 package org.simpleflatmapper.jooq.test.books;
 
+import org.simpleflatmapper.jooq.test.JSONObjectTest494;
+
 import java.util.UUID;
 
 public class Label {
@@ -7,15 +9,16 @@ public class Label {
     private UUID uuid;
     private String name;
     private Boolean obsolete;
+    private JSONObjectTest494.File file;
 
-
-    public Label(Integer id, UUID uuid, String name, Boolean obsolete) {
+    public Label(Integer id, UUID uuid, String name, Boolean obsolete,
+                 JSONObjectTest494.File file) {
         this.id = id;
         this.uuid = uuid;
         this.name = name;
         this.obsolete = obsolete;
+        this.file = file;
     }
-
 
     public Integer getId() {
         return id;
@@ -31,6 +34,10 @@ public class Label {
 
     public Boolean getObsolete() {
         return obsolete;
+    }
+
+    public JSONObjectTest494.File getFile() {
+        return file;
     }
 
     @Override

--- a/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/books/Labels.java
+++ b/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/books/Labels.java
@@ -5,20 +5,13 @@
 
 package org.simpleflatmapper.jooq.test.books;
 
-import java.util.List;
-import java.util.UUID;
-import org.jooq.Field;
-import org.jooq.ForeignKey;
-import org.jooq.Identity;
-import org.jooq.Name;
-import org.jooq.Record;
-import org.jooq.Schema;
-import org.jooq.Table;
-import org.jooq.TableField;
-import org.jooq.UniqueKey;
+import org.jooq.*;
 import org.jooq.impl.DSL;
 import org.jooq.impl.SQLDataType;
 import org.jooq.impl.TableImpl;
+
+import java.util.List;
+import java.util.UUID;
 
 public class Labels extends TableImpl<LabelsRecord> {
     private static final long serialVersionUID = 359479367L;
@@ -27,6 +20,7 @@ public class Labels extends TableImpl<LabelsRecord> {
     public final TableField<LabelsRecord, UUID> UUID;
     public final TableField<LabelsRecord, String> NAME;
     public final TableField<LabelsRecord, Boolean> OBSOLETE;
+    public final TableField<LabelsRecord, String> FILE;
 
     public Class<LabelsRecord> getRecordType() {
         return LabelsRecord.class;
@@ -54,6 +48,7 @@ public class Labels extends TableImpl<LabelsRecord> {
         this.UUID = createField("uuid", SQLDataType.UUID.nullable(false), this, "");
         this.NAME = createField("name", SQLDataType.VARCHAR(500).nullable(false), this, "");
         this.OBSOLETE = createField("obsolete", SQLDataType.BOOLEAN.nullable(false).defaultValue(DSL.field("false", SQLDataType.BOOLEAN)), this, "");
+        this.FILE = createField("file", SQLDataType.VARCHAR.nullable(true), this, "");
     }
 
     public <O extends Record> Labels(Table<O> child, ForeignKey<O, LabelsRecord> key) {
@@ -62,6 +57,7 @@ public class Labels extends TableImpl<LabelsRecord> {
         this.UUID = createField("uuid", SQLDataType.UUID.nullable(false), this, "");
         this.NAME = createField("name", SQLDataType.VARCHAR(500).nullable(false), this, "");
         this.OBSOLETE = createField("obsolete", SQLDataType.BOOLEAN.nullable(false).defaultValue(DSL.field("false", SQLDataType.BOOLEAN)), this, "");
+        this.FILE = createField("file", SQLDataType.VARCHAR.nullable(true), this, "");
     }
 
     public Schema getSchema() {

--- a/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/books/LabelsRecord.java
+++ b/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/books/LabelsRecord.java
@@ -5,10 +5,13 @@
 
 package org.simpleflatmapper.jooq.test.books;
 
-import java.util.UUID;
-
-import org.jooq.*;
+import org.jooq.Field;
+import org.jooq.Record1;
+import org.jooq.Record4;
+import org.jooq.Row4;
 import org.jooq.impl.UpdatableRecordImpl;
+
+import java.util.UUID;
 
 public class LabelsRecord extends UpdatableRecordImpl<LabelsRecord> implements Record4<Integer, UUID, String, Boolean> {
     private static final long serialVersionUID = 1840732564L;
@@ -45,6 +48,13 @@ public class LabelsRecord extends UpdatableRecordImpl<LabelsRecord> implements R
         return (Boolean)this.get(3);
     }
 
+    public void setFile(String value) {
+        this.set(4, value);
+    }
+
+    public String getFile() {
+        return (String)this.get(4);
+    }
 
     public Record1<Integer> key() {
         return (Record1)super.key();

--- a/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/books/SelectQueryMapperTest.java
+++ b/sfm-jooq/src/test/java/org/simpleflatmapper/jooq/test/books/SelectQueryMapperTest.java
@@ -43,7 +43,7 @@ public class SelectQueryMapperTest {
 		SelectQueryMapper<Label> mapper = SelectQueryMapperFactory.newInstance().newMapper(Label.class);
 
 		UUID uuid1 = UUID.randomUUID();
-		Label label = new Label(1, uuid1, "l1", false);
+		Label label = new Label(1, uuid1, "l1", false, null);
 
 
 

--- a/sfm-map/src/main/java/org/simpleflatmapper/map/property/ContextualConverterFactoryProperty.java
+++ b/sfm-map/src/main/java/org/simpleflatmapper/map/property/ContextualConverterFactoryProperty.java
@@ -1,0 +1,16 @@
+package org.simpleflatmapper.map.property;
+
+import org.simpleflatmapper.converter.ContextualConverterFactory;
+
+public class ContextualConverterFactoryProperty<I, O> {
+
+    public final ContextualConverterFactory<I, O> factory;
+
+    public ContextualConverterFactoryProperty(ContextualConverterFactory<I, O> factory) {
+        this.factory = factory;
+    }
+
+    public static <I, O> ContextualConverterFactoryProperty of(ContextualConverterFactory<I, O> converter) {
+        return new ContextualConverterFactoryProperty<I, O>(converter);
+    }
+}


### PR DESCRIPTION
`JooqBiConverter` should be shared between `RecordMapper` and `RecordUnmapper`. It should be helpful to make code more lean and readable.

Usage:

```java
List<JooqBiConverter> converters = new ArrayList<>();
converters.add(new JooqBiConverter<String, JSONObjectTest494.File>() {
	@Override
	public boolean match(Type modelType) {
		return TypeHelper.areEquals(modelType, JSONObjectTest494.File.class);
	}
	@Override
	public JSONObjectTest494.File get(String name, Context context) throws Exception {
		return new JSONObjectTest494.File(0L, name, null);
	}
	@Override
	public String convert(JSONObjectTest494.File file, Context context) throws Exception {
		return file.name;
	}
});

JooqMapperFactory mapperFactory = JooqMapperFactory.newInstance()
		.addBiConverters(converters);
```