### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,7 @@
                             <excludes>
                                 <exclude>**/module-info.java</exclude>
                             </excludes>
+                        	<fork>true</fork>
                         </configuration>
 
                         <executions>
@@ -513,6 +514,7 @@
                         <configuration>
                             <source>9</source>
                             <target>9</target>
+                        	<fork>true</fork>
                         </configuration>
                         <dependencies>
                             <dependency>


### PR DESCRIPTION

Maven allows you to run the compiler as a separate process by setting `<fork>true</fork>`. This feature can lead to much less garbage collection and make Maven build faster. This project has more than 1000 source files. We can consider enabling this feature.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
